### PR TITLE
Updated grabscreen for Single Monitor as it wasn't working on Windows 10 or 11.

### DIFF
--- a/miscellaneous/Single Monitor/functions/grabscreen.py
+++ b/miscellaneous/Single Monitor/functions/grabscreen.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
-import win32gui, win32ui, win32con, win32api
+import win32gui, win32ui
+from ctypes import windll
 
 def grab_screen(screen_name=None, region=None):
 
@@ -16,10 +17,9 @@ def grab_screen(screen_name=None, region=None):
         width = x2 - left + 1
         height = y2 - top + 1
     else:
-        width = win32api.GetSystemMetrics(win32con.SM_CXVIRTUALSCREEN)
-        height = win32api.GetSystemMetrics(win32con.SM_CYVIRTUALSCREEN)
-        left = win32api.GetSystemMetrics(win32con.SM_XVIRTUALSCREEN)
-        top = win32api.GetSystemMetrics(win32con.SM_YVIRTUALSCREEN)
+        left, top, right, bottom = win32gui.GetWindowRect(hwin)
+        width = right - left
+        height = bottom - top
 
     hwindc = win32gui.GetWindowDC(hwin)
     srcdc = win32ui.CreateDCFromHandle(hwindc)
@@ -27,15 +27,17 @@ def grab_screen(screen_name=None, region=None):
     bmp = win32ui.CreateBitmap()
     bmp.CreateCompatibleBitmap(srcdc, width, height)
     memdc.SelectObject(bmp)
-    memdc.BitBlt((0, 0), (width, height), srcdc, (left, top), win32con.SRCCOPY)
+
+    windll.user32.PrintWindow(hwin, memdc.GetSafeHdc(), 2)
 
     signedIntsArray = bmp.GetBitmapBits(True)
     img = np.fromstring(signedIntsArray, dtype='uint8')
     img.shape = (height, width, 4)
 
-    srcdc.DeleteDC()
-    memdc.DeleteDC()
-    win32gui.ReleaseDC(hwin, hwindc)
     win32gui.DeleteObject(bmp.GetHandle())
+    memdc.DeleteDC()
+    srcdc.DeleteDC()
+    win32gui.ReleaseDC(hwin, hwindc)
+ 
 
     return cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)


### PR DESCRIPTION
For some reason the calls to the win32 api to grab the screen for the single monitor setup weren't working on Windows 10 or 11. Updated to calls that do work. Tested on Windows 10